### PR TITLE
error('Duration of data in params.tapers is inconsistent with movingwin(...

### DIFF
--- a/spectral_analysis/continuous/mtspecgramc.m
+++ b/spectral_analysis/continuous/mtspecgramc.m
@@ -56,10 +56,11 @@ function [S,t,f,Serr]=mtspecgramc(data,movingwin,params)
 if nargin < 2; error('Need data and window parameters'); end;
 if nargin < 3; params=[]; end;
 
-[tapers,pad,Fs,fpass,err,trialave,params]=getparams(params);
 if length(params.tapers)==3 & movingwin(1)~=params.tapers(2);
     error('Duration of data in params.tapers is inconsistent with movingwin(1), modify params.tapers(2) to proceed')
 end
+[tapers,pad,Fs,fpass,err,trialave,params]=getparams(params);
+
 
 if nargout > 3 && err(1)==0; 
 %   Cannot compute error bars with err(1)=0. change params and run again.


### PR DESCRIPTION
...1), modify params.tapers(2) to proceed') would never be issued because getparams sets length(params.tapers) to 2. This small fix will allow the error to be issued when appropriate.
